### PR TITLE
컴포즈 Convention Plugin 구현 및 모든 모듈에 각 ConventionPlugin 적용

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,15 +2,14 @@ plugins {
     alias(libs.plugins.sow.android.application)
     alias(libs.plugins.sow.hilt)
     alias(libs.plugins.sow.android.application.firebase)
+    alias(libs.plugins.sow.android.application.compose)
 }
 
 android {
     namespace = "com.yongjincompany.shoesofworld"
-    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.yongjincompany.shoesofworld"
-        minSdk = 24
         versionCode = 1
         versionName = "1.0"
 
@@ -33,13 +32,6 @@ android {
             )
         }
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
 
     buildFeatures {
         viewBinding = true
@@ -48,9 +40,6 @@ android {
 
 dependencies {
     implementation(project(":feature:home"))
-
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -35,6 +35,14 @@ gradlePlugin {
             id = "sow.android.application"
             implementationClass = "AndroidApplicationConventionPlugin"
         }
+        register("androidApplicationCompose") {
+            id = "sow.android.application.compose"
+            implementationClass = "AndroidApplicationComposeConventionPlugin"
+        }
+        register("androidLibraryCompose") {
+            id = "sow.android.library.compose"
+            implementationClass = "AndroidLibraryComposeConventionPlugin"
+        }
         register("androidLibrary") {
             id = "sow.android.library"
             implementationClass = "AndroidLibraryConventionPlugin"

--- a/build-logic/convention/src/main/java/com/yongincompany/convention/AndroidApplicationComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/com/yongincompany/convention/AndroidApplicationComposeConventionPlugin.kt
@@ -1,0 +1,18 @@
+import com.android.build.api.dsl.ApplicationExtension
+import com.yongincompany.convention.util.configureAndroidCompose
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.getByType
+
+class AndroidApplicationComposeConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            apply(plugin = "com.android.application")
+            apply(plugin = "org.jetbrains.kotlin.plugin.compose")
+
+            val extension = extensions.getByType<ApplicationExtension>()
+            configureAndroidCompose(extension)
+        }
+    }
+}

--- a/build-logic/convention/src/main/java/com/yongincompany/convention/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/com/yongincompany/convention/AndroidLibraryComposeConventionPlugin.kt
@@ -1,0 +1,18 @@
+import com.android.build.gradle.LibraryExtension
+import com.yongincompany.convention.util.configureAndroidCompose
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.getByType
+
+class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            apply(plugin = "com.android.library")
+            apply(plugin = "org.jetbrains.kotlin.plugin.compose")
+
+            val extension = extensions.getByType<LibraryExtension>()
+            configureAndroidCompose(extension)
+        }
+    }
+}

--- a/build-logic/convention/src/main/java/com/yongincompany/convention/JvmLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/com/yongincompany/convention/JvmLibraryConventionPlugin.kt
@@ -1,5 +1,4 @@
-package com.yongincompany.convention.util
-
+import com.yongincompany.convention.util.configureKotlinJvm
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 

--- a/build-logic/convention/src/main/java/com/yongincompany/convention/util/AndroidCompose.kt
+++ b/build-logic/convention/src/main/java/com/yongincompany/convention/util/AndroidCompose.kt
@@ -1,0 +1,44 @@
+package com.yongincompany.convention.util
+
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import org.gradle.kotlin.dsl.assign
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
+
+internal fun Project.configureAndroidCompose(
+    commonExtension: CommonExtension<*, *, *, *, *, *>,
+) {
+    commonExtension.apply {
+        buildFeatures {
+            compose = true
+        }
+
+        dependencies {
+            val bom = libs.findLibrary("androidx-compose-bom").get()
+            add("implementation", platform(bom))
+            add("androidTestImplementation", platform(bom))
+            add("implementation", libs.findLibrary("androidx-compose-ui-tooling-preview").get())
+            add("debugImplementation", libs.findLibrary("androidx-compose-ui-tooling").get())
+        }
+    }
+
+    extensions.configure<ComposeCompilerGradlePluginExtension> {
+        fun Provider<String>.onlyIfTrue() = flatMap { provider { it.takeIf(String::toBoolean) } }
+        fun Provider<*>.relativeToRootProject(dir: String) = flatMap {
+            rootProject.layout.buildDirectory.dir(projectDir.toRelativeString(rootDir))
+        }.map { it.dir(dir) }
+
+        project.providers.gradleProperty("enableComposeCompilerMetrics").onlyIfTrue()
+            .relativeToRootProject("compose-metrics")
+            .let(metricsDestination::set)
+
+        project.providers.gradleProperty("enableComposeCompilerReports").onlyIfTrue()
+            .relativeToRootProject("compose-reports")
+            .let(reportsDestination::set)
+
+        enableStrongSkippingMode = true
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.jetbrains.kotlin.jvm) apply false
     alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.compose) apply  false
     alias(libs.plugins.gms) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotlin.serialization) apply false

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,41 +1,10 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.hilt)
+    alias(libs.plugins.sow.android.library)
+    alias(libs.plugins.sow.hilt)
 }
 
 android {
     namespace = "com.yongjincompany.core.data"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 24
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-    buildFeatures {
-        buildConfig = true
-    }
 }
 
 dependencies {
@@ -43,16 +12,12 @@ dependencies {
     implementation(libs.androidx.appcompat)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
 
     implementation(libs.retrofit)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.retrofit.kotlin.serialization)
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging)
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
-    implementation(libs.retrofit.kotlin.serialization)
 
     implementation(project(":core:domain"))
 }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -1,19 +1,4 @@
 plugins {
-    id("java-library")
-    alias(libs.plugins.jetbrains.kotlin.jvm)
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-}
-
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
-}
-
-dependencies {
-    implementation(libs.inject)
+    alias(libs.plugins.sow.jvm.library)
+    alias(libs.plugins.sow.hilt)
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -1,39 +1,12 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.sow.android.library)
 }
 
 android {
     namespace = "com.yongjincompany.core.ui"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 24
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
 }
 
 dependencies {
-
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.sow.android.feature)
+    alias(libs.plugins.sow.android.library.compose)
 }
 
 android {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,9 @@ junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 appcompat = "1.7.0"
 material = "1.12.0"
+androidxComposeAlpha = "1.7.8"
+androidxComposeBom = "2025.02.00"
+androidxComposeRuntimeTracing = "1.7.8"
 activity = "1.10.0"
 constraintlayout = "2.2.0"
 jetbrainsKotlinJvm = "2.0.0"
@@ -31,6 +34,17 @@ gmsPlugin = "4.4.2"
 recyclerview = "1.4.0"
 
 [libraries]
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
+androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "androidxComposeAlpha" }
+androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
+androidx-compose-runtime-tracing = { group = "androidx.compose.runtime", name = "runtime-tracing", version.ref = "androidxComposeRuntimeTracing" }
+androidx-compose-ui-test = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "androidxComposeAlpha" }
+androidx-compose-ui-testManifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-compose-ui-util = { group = "androidx.compose.ui", name = "ui-util" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,3 +106,5 @@ sow-android-library = { id = "sow.android.library", version = "unspecified" }
 sow-hilt = { id = "sow.hilt", version = "unspecified" }
 sow-jvm-library = { id = "sow.jvm.library", version = "unspecified" }
 sow-android-test = { id = "sow.android.test", version = "unspecified" }
+sow-android-library-compose = { id = "sow.android.library.compose", version = "unspecified" }
+sow-android-application-compose = { id = "sow.android.application.compose", version = "unspecified" }


### PR DESCRIPTION
## PR 작업 요약
Compose로 작업을 위해 Compose 종속성과 ConventionPlugin을 만들고 아직 ConventionPlugin이 적용되어있지않은 모듈에 ConventionPlugin을 적용합니다.


## 작업 내용
- 컴포즈 종속성 추가
- 컴포즈 Convention Plugin 구현
    - configureAndroidCompose 확장 함수 구현 
    - Application, Library에 대한 Compose ConventionPlugin 구현 
- JvmLibraryConventionPlugin을 인식하지 못하는 이슈 해결
    - package외부로 파일 이동
- 각 모듈들에 conventionPlugin적용 

## 추가 사항
-  현재 xml로 홈화면이 구현되어있기에 일단 app의 build.gradle.kts의 viewBinding 설정을 유지해놓았고 Compose로 홈화면 구현 작업을 시작할 때에 해당 설정을 지워줄 예정입니다!
```kotlin
// app/build.gradle.kts
 buildFeatures {
        viewBinding = true // compose로 홈화면 구현 작업을 시작할 때 제거 예정
    }
```