### PR TITLE
Room 도입 및 캐싱로직 구현

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.sow.android.library)
     alias(libs.plugins.sow.hilt)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -10,14 +11,14 @@ android {
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-
     implementation(libs.retrofit)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.retrofit.kotlin.serialization)
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging)
+    implementation(libs.androidx.room.ktx)
+    implementation(libs.androidx.room.runtime)
+    ksp(libs.androidx.room.compiler)
 
     implementation(project(":core:domain"))
 }

--- a/core/data/src/main/java/com/yongjincompany/core/data/di/DataBaseModule.kt
+++ b/core/data/src/main/java/com/yongjincompany/core/data/di/DataBaseModule.kt
@@ -1,0 +1,32 @@
+package com.yongjincompany.core.data.di
+
+import android.content.Context
+import androidx.room.Room
+import com.yongjincompany.core.data.local.SowDatabase
+import com.yongjincompany.core.data.local.dao.ShoesDao
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): SowDatabase {
+        return Room.databaseBuilder(
+            context,
+            SowDatabase::class.java,
+            "sow_database"
+        ).build()
+    }
+
+    @Provides
+    fun provideShoesDao(database: SowDatabase): ShoesDao {
+        return database.shoesDao()
+    }
+}

--- a/core/data/src/main/java/com/yongjincompany/core/data/di/DataSourceModule.kt
+++ b/core/data/src/main/java/com/yongjincompany/core/data/di/DataSourceModule.kt
@@ -1,5 +1,7 @@
 package com.yongjincompany.core.data.di
 
+import com.yongjincompany.core.data.local.datasource.LocalShoesDataSource
+import com.yongjincompany.core.data.local.datasource.LocalShoesDataSourceImpl
 import com.yongjincompany.core.data.remote.datasource.RemoteShoesDataSource
 import com.yongjincompany.core.data.remote.datasource.RemoteShoesDataSourceImpl
 import dagger.Binds
@@ -15,4 +17,9 @@ abstract class DataSourceModule {
     abstract fun provideRemoteShoesDataSource(
         remoteShoesDataSourceImpl: RemoteShoesDataSourceImpl
     ): RemoteShoesDataSource
+
+    @Binds
+    abstract fun provideLocalShoesDataSource(
+        localShoesDataSourceImpl: LocalShoesDataSourceImpl
+    ): LocalShoesDataSource
 }

--- a/core/data/src/main/java/com/yongjincompany/core/data/local/SowDatabase.kt
+++ b/core/data/src/main/java/com/yongjincompany/core/data/local/SowDatabase.kt
@@ -1,0 +1,11 @@
+package com.yongjincompany.core.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.yongjincompany.core.data.local.dao.ShoesDao
+import com.yongjincompany.core.data.local.entity.ShoesEntity
+
+@Database(entities = [ShoesEntity::class], version = 1)
+abstract class SowDatabase : RoomDatabase() {
+    abstract fun shoesDao(): ShoesDao
+}

--- a/core/data/src/main/java/com/yongjincompany/core/data/local/dao/ShoesDao.kt
+++ b/core/data/src/main/java/com/yongjincompany/core/data/local/dao/ShoesDao.kt
@@ -1,0 +1,16 @@
+package com.yongjincompany.core.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.yongjincompany.core.data.local.entity.ShoesEntity
+
+@Dao
+interface ShoesDao {
+    @Query("SELECT * FROM shoes")
+    suspend fun selectAllFromShoesTable(): List<ShoesEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertShoes(shoes: List<ShoesEntity>)
+}

--- a/core/data/src/main/java/com/yongjincompany/core/data/local/datasource/LocalShoesDataSource.kt
+++ b/core/data/src/main/java/com/yongjincompany/core/data/local/datasource/LocalShoesDataSource.kt
@@ -1,0 +1,8 @@
+package com.yongjincompany.core.data.local.datasource
+
+import com.yongjincompany.core.data.local.entity.ShoesEntity
+
+interface LocalShoesDataSource {
+    suspend fun selectAllFromShoesTable(): List<ShoesEntity>
+    suspend fun insertShoes(shoes: List<ShoesEntity>)
+}

--- a/core/data/src/main/java/com/yongjincompany/core/data/local/datasource/LocalShoesDataSourceImpl.kt
+++ b/core/data/src/main/java/com/yongjincompany/core/data/local/datasource/LocalShoesDataSourceImpl.kt
@@ -1,0 +1,15 @@
+package com.yongjincompany.core.data.local.datasource
+
+import com.yongjincompany.core.data.local.dao.ShoesDao
+import com.yongjincompany.core.data.local.entity.ShoesEntity
+import javax.inject.Inject
+
+class LocalShoesDataSourceImpl @Inject constructor(
+    private val shoesDao: ShoesDao
+) : LocalShoesDataSource {
+    override suspend fun selectAllFromShoesTable(): List<ShoesEntity> =
+        shoesDao.selectAllFromShoesTable()
+
+    override suspend fun insertShoes(shoes: List<ShoesEntity>) =
+        shoesDao.insertShoes(shoes)
+}

--- a/core/data/src/main/java/com/yongjincompany/core/data/local/entity/ShoesEntity.kt
+++ b/core/data/src/main/java/com/yongjincompany/core/data/local/entity/ShoesEntity.kt
@@ -1,0 +1,13 @@
+package com.yongjincompany.core.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "shoes")
+data class ShoesEntity(
+    @PrimaryKey val id: Int,
+    val name: String,
+    val brandName: String,
+    val imageUrl: String,
+    val bookmarkCount: Int
+)

--- a/core/data/src/main/java/com/yongjincompany/core/data/remote/mapper/ShoesMapper.kt
+++ b/core/data/src/main/java/com/yongjincompany/core/data/remote/mapper/ShoesMapper.kt
@@ -1,9 +1,28 @@
 package com.yongjincompany.core.data.remote.mapper
 
+import com.yongjincompany.core.data.local.entity.ShoesEntity
 import com.yongjincompany.core.data.remote.model.response.ShoesResponse
-import com.yongjincompany.core.domain.entity.ShoesEntity
+import com.yongjincompany.core.domain.entity.Shoes
 
-internal fun ShoesResponse.responseToEntity(): ShoesEntity =
+internal fun ShoesResponse.responseToEntity(): Shoes =
+    Shoes(
+        id,
+        name,
+        brandName,
+        imageUrl,
+        bookmarkCount
+    )
+
+internal fun ShoesEntity.localEntityToDomainEntity(): Shoes =
+    Shoes(
+        id,
+        name,
+        brandName,
+        imageUrl,
+        bookmarkCount
+    )
+
+internal fun ShoesResponse.responseToLocalEntity(): ShoesEntity =
     ShoesEntity(
         id,
         name,

--- a/core/data/src/main/java/com/yongjincompany/core/data/repository/ShoesRepositoryImpl.kt
+++ b/core/data/src/main/java/com/yongjincompany/core/data/repository/ShoesRepositoryImpl.kt
@@ -1,15 +1,32 @@
 package com.yongjincompany.core.data.repository
 
+import com.yongjincompany.core.data.local.datasource.LocalShoesDataSource
 import com.yongjincompany.core.data.remote.datasource.RemoteShoesDataSource
+import com.yongjincompany.core.data.remote.mapper.localEntityToDomainEntity
 import com.yongjincompany.core.data.remote.mapper.responseToEntity
-import com.yongjincompany.core.domain.entity.ShoesEntity
+import com.yongjincompany.core.data.remote.mapper.responseToLocalEntity
+import com.yongjincompany.core.domain.entity.Shoes
 import com.yongjincompany.core.domain.repository.ShoesRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class ShoesRepositoryImpl @Inject constructor(
-    private val remoteShoesDataSource: RemoteShoesDataSource
+    private val remoteShoesDataSource: RemoteShoesDataSource,
+    private val localShoesDataSource: LocalShoesDataSource
 ) : ShoesRepository {
-    override suspend fun fetchAllShoesList(): List<ShoesEntity> {
-        return remoteShoesDataSource.fetchAllShoesList().map { it.responseToEntity() }
-    }
+    override suspend fun fetchAllShoesList(): Flow<List<Shoes>> = flow {
+        emit(localShoesDataSource.selectAllFromShoesTable().map { it.localEntityToDomainEntity() })
+
+        runCatching {
+            remoteShoesDataSource.fetchAllShoesList()
+        }.onSuccess { allShoesList ->
+            localShoesDataSource.insertShoes(allShoesList.map { shoes -> shoes.responseToLocalEntity() })
+            emit(allShoesList.map { it.responseToEntity() })
+        }.onFailure {
+            //TODO: errorHandling구현하면서 처리 필요.
+        }
+    }.flowOn(Dispatchers.IO)
 }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -2,3 +2,7 @@ plugins {
     alias(libs.plugins.sow.jvm.library)
     alias(libs.plugins.sow.hilt)
 }
+
+dependencies {
+    implementation(libs.kotlinx.coroutines.core)
+}

--- a/core/domain/src/main/java/com/yongjincompany/core/domain/entity/Shoes.kt
+++ b/core/domain/src/main/java/com/yongjincompany/core/domain/entity/Shoes.kt
@@ -1,6 +1,6 @@
 package com.yongjincompany.core.domain.entity
 
-data class ShoesEntity(
+data class Shoes(
     val id: Int,
     val name: String,
     val brandName: String,

--- a/core/domain/src/main/java/com/yongjincompany/core/domain/repository/ShoesRepository.kt
+++ b/core/domain/src/main/java/com/yongjincompany/core/domain/repository/ShoesRepository.kt
@@ -1,7 +1,8 @@
 package com.yongjincompany.core.domain.repository
 
-import com.yongjincompany.core.domain.entity.ShoesEntity
+import com.yongjincompany.core.domain.entity.Shoes
+import kotlinx.coroutines.flow.Flow
 
 interface ShoesRepository {
-    suspend fun fetchAllShoesList(): List<ShoesEntity>
+    suspend fun fetchAllShoesList(): Flow<List<Shoes>>
 }

--- a/core/domain/src/main/java/com/yongjincompany/core/domain/usecase/FetchAllShoesUseCase.kt
+++ b/core/domain/src/main/java/com/yongjincompany/core/domain/usecase/FetchAllShoesUseCase.kt
@@ -1,12 +1,13 @@
 package com.yongjincompany.core.domain.usecase
 
-import com.yongjincompany.core.domain.entity.ShoesEntity
+import com.yongjincompany.core.domain.entity.Shoes
 import com.yongjincompany.core.domain.repository.ShoesRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class FetchAllShoesUseCase @Inject constructor(
     private val shoesRepository: ShoesRepository
 ) {
-    suspend operator fun invoke(): List<ShoesEntity> =
+    suspend operator fun invoke(): Flow<List<Shoes>> =
         shoesRepository.fetchAllShoesList()
 }

--- a/feature/home/src/main/java/com/yongjincompany/feature/home/HomeFragment.kt
+++ b/feature/home/src/main/java/com/yongjincompany/feature/home/HomeFragment.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.GridLayoutManager
 import com.yongjincompany.core.domain.entity.BannerEntity
 import com.yongjincompany.core.domain.entity.BrandCategoryEntity
-import com.yongjincompany.core.domain.entity.ShoesEntity
+import com.yongjincompany.core.domain.entity.Shoes
 import com.yongjincompany.feature.home.adapter.banner.BannerAdapter
 import com.yongjincompany.feature.home.adapter.brand_category.BrandCategoryAdapter
 import com.yongjincompany.feature.home.adapter.shoes.ShoesAdapter
@@ -135,28 +135,28 @@ class HomeFragment : Fragment() {
         )
 
         private val shoesItemList = listOf(
-            ShoesEntity(
+            Shoes(
                 id = 0,
                 name = "에어포스 1",
                 brandName = "나이키",
                 imageUrl = "",
                 bookmarkCount = 0
             ),
-            ShoesEntity(
+            Shoes(
                 id = 1,
                 name = "용진포스 2",
                 brandName = "퓨마",
                 imageUrl = "",
                 bookmarkCount = 100
             ),
-            ShoesEntity(
+            Shoes(
                 id = 2,
                 name = "공기포스 3",
                 brandName = "아디다스",
                 imageUrl = "",
                 bookmarkCount = 0
             ),
-            ShoesEntity(
+            Shoes(
                 id = 3,
                 name = "허헣 3",
                 brandName = "프로스펙스",

--- a/feature/home/src/main/java/com/yongjincompany/feature/home/adapter/shoes/ShoesAdapter.kt
+++ b/feature/home/src/main/java/com/yongjincompany/feature/home/adapter/shoes/ShoesAdapter.kt
@@ -4,11 +4,11 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
-import com.yongjincompany.core.domain.entity.ShoesEntity
+import com.yongjincompany.core.domain.entity.Shoes
 import com.yongjincompany.feature.home.HomeFragment
 import com.yongjincompany.feature.home.databinding.ItemShoesBinding
 
-internal class ShoesAdapter : ListAdapter<ShoesEntity, ShoesViewHolder>(DiffCallback) {
+internal class ShoesAdapter : ListAdapter<Shoes, ShoesViewHolder>(DiffCallback) {
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -31,12 +31,12 @@ internal class ShoesAdapter : ListAdapter<ShoesEntity, ShoesViewHolder>(DiffCall
         return HomeFragment.SHOES_VIEW_TYPE
     }
 
-    private companion object DiffCallback : DiffUtil.ItemCallback<ShoesEntity>() {
-        override fun areItemsTheSame(oldItem: ShoesEntity, newItem: ShoesEntity): Boolean {
+    private companion object DiffCallback : DiffUtil.ItemCallback<Shoes>() {
+        override fun areItemsTheSame(oldItem: Shoes, newItem: Shoes): Boolean {
             return oldItem.id == newItem.id
         }
 
-        override fun areContentsTheSame(oldItem: ShoesEntity, newItem: ShoesEntity): Boolean {
+        override fun areContentsTheSame(oldItem: Shoes, newItem: Shoes): Boolean {
             return oldItem == newItem
         }
     }

--- a/feature/home/src/main/java/com/yongjincompany/feature/home/adapter/shoes/ShoesViewHolder.kt
+++ b/feature/home/src/main/java/com/yongjincompany/feature/home/adapter/shoes/ShoesViewHolder.kt
@@ -2,12 +2,12 @@ package com.yongjincompany.feature.home.adapter.shoes
 
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
-import com.yongjincompany.core.domain.entity.ShoesEntity
+import com.yongjincompany.core.domain.entity.Shoes
 import com.yongjincompany.feature.home.databinding.ItemShoesBinding
 
 internal class ShoesViewHolder(private val binding: ItemShoesBinding) : RecyclerView.ViewHolder(binding.root) {
     //TODO: 여기도 새로 recyclerview 추가해야함
-    fun bind(data: ShoesEntity) {
+    fun bind(data: Shoes) {
         Glide.with(binding.root.context)
             .load(data.imageUrl)
             .into(binding.ivShoes)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ androidxComposeRuntimeTracing = "1.7.8"
 activity = "1.10.0"
 constraintlayout = "2.2.0"
 jetbrainsKotlinJvm = "2.0.0"
+kotlinxCoroutines = "1.8.0"
 fragment = "1.8.6"
 androidTools = "31.8.1"
 lifecycle = "2.8.7"
@@ -61,8 +62,10 @@ androidx-room-compiler = { group = "androidx.room", name = "room-compiler", vers
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 retrofit-kotlin-serialization = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationJson" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }


### PR DESCRIPTION
## PR 작업 요약
Room을 도입하고 캐싱로직을 구현해주었습니다.


## 작업 내용
- Domain모듈에 coroutine-core 종속성을 추가
    - Domain모듈은 Kotlin Library모듈이기에 core종속성을 추가. 
- Room도입
- Room에서 사용되는 Entity와 Domain의 Entity name이 겹치는 부분이 존재하여 Room의 Entity에만 model명 뒤에 Entity를 붙혀주도록 하고 Domain의 Entity에는 model명만 오도록 결정.
    ```kotlin
    //Domain - Entity
    data class Shoes(...)

    //Room - Entity
    data class ShoesEntity(...)
    ```
- 신발목록을 insert하고 query문으로 불러오기 위해 Dao와 Database, Entity, LocalDataSource정의 
- Database와 LocalShoesDataSource에 대한 DI코드 작성 
- Repository와 UseCase에서 Flow를 사용하도록 수정
- RepositoryImpl에서 flow 블록 내에 캐싱로직을 구현
    - 먼저 저장되어있는 신발 목록을 반환하고 api호출에 성공하면 api에서 불러온 신발 목록을 반환하도록 구현. 

## 추가 사항
에러 처리에 대한 부분은 에러 핸들링 관련 태스크를 진행할 때 처리할 예정입니다.
또한 추후 해당 PR에서 처리한 방식의 캐싱 로직 부분의 보일러 플레이트 코드를 축약할 수 있는 CacheUtil 함수나 클래스를 만들어줄 예정입니다. 