### PR TITLE
firebase bom을 사용하도록 수정 & configure cahce 활성화

### DIFF
--- a/build-logic/convention/src/main/java/com/yongincompany/convention/AndroidApplicationFirebaseConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/com/yongincompany/convention/AndroidApplicationFirebaseConventionPlugin.kt
@@ -13,8 +13,8 @@ class AndroidApplicationFirebaseConventionPlugin : Plugin<Project> {
             dependencies {
                 val bom = libs.findLibrary("firebase-bom").get()
                 add("implementation", platform(bom))
-                "implementation"(libs.findLibrary("firebase.analytics.ktx").get())
-                "implementation"(libs.findLibrary("firebase.cloud.messaging.ktx").get())
+                "implementation"(libs.findLibrary("firebase.analytics").get())
+                "implementation"(libs.findLibrary("firebase.cloud.messaging").get())
             }
         }
     }

--- a/build-logic/convention/src/main/java/com/yongincompany/convention/AndroidApplicationFirebaseConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/com/yongincompany/convention/AndroidApplicationFirebaseConventionPlugin.kt
@@ -8,11 +8,13 @@ class AndroidApplicationFirebaseConventionPlugin : Plugin<Project> {
         with(target) {
             with(pluginManager) {
                 apply("com.google.gms.google-services")
+                apply("com.google.firebase.crashlytics")
             }
 
             dependencies {
                 val bom = libs.findLibrary("firebase-bom").get()
                 add("implementation", platform(bom))
+                "implementation"(libs.findLibrary("firebase.crashlytics").get())
                 "implementation"(libs.findLibrary("firebase.analytics").get())
                 "implementation"(libs.findLibrary("firebase.cloud.messaging").get())
             }

--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -1,3 +1,5 @@
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,9 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.jetbrains.kotlin.jvm) apply false
     alias(libs.plugins.hilt) apply false
-    alias(libs.plugins.compose) apply  false
+    alias(libs.plugins.compose) apply false
     alias(libs.plugins.gms) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotlin.serialization) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,15 +11,10 @@ androidxComposeBom = "2025.02.00"
 androidxComposeRuntimeTracing = "1.7.8"
 jetbrainsKotlinJvm = "2.0.0"
 kotlinxCoroutines = "1.8.0"
-fragment = "1.8.6"
 androidTools = "31.8.1"
 lifecycle = "2.8.7"
 retrofit = "2.11.0"
 firebaseBom = "33.9.0"
-firebaseCrashlytics = "19.4.0"
-firebaseFcm = "24.1.0"
-firebaseConfig = "22.1.0"
-firebaseAnaylitics = "22.2.0"
 kotlinxSerializationJson = "1.6.3"
 retrofitKotlinxSerializationJson = "1.0.0"
 okhttp = "4.12.0"
@@ -63,12 +58,10 @@ okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor",
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
-firebase-analytics-ktx = { group = "com.google.firebase", name = "firebase-analytics-ktx", version.ref = "firebaseAnaylitics" }
-firebase-crashlytics-ktx = { group = "com.google.firebase", name = "firebase-crashlytics-ktx", version.ref = "firebaseCrashlytics" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
-firebase-config-ktx = { group = "com.google.firebase", name = "firebase-config-ktx", version.ref = "firebaseConfig" }
-firebase-cloud-messaging-ktx = { group = "com.google.firebase", name = "firebase-messaging-ktx", version.ref = "firebaseFcm" }
-androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
+firebase-cloud-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 inject = "javax.inject:javax.inject:1"
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }


### PR DESCRIPTION
## PR 작업 요약
firebase bom을 사용하도록 수정해주었습니다.


## 작업 내용
- configuration chache 활성화
- firebase bom을 사용하여 analytics, fcm종속성을 선언하도록 수정
- bom을 사용함으로써 버전 제거 및 compose도입으로 인한 androidx-fragment-ktx 종속성 제거
- firebase-crashlytics 종속성 추가


## 추가 사항
X